### PR TITLE
JavaScript Object Mapping Manual Page

### DIFF
--- a/javascript-manual/modules/ROOT/content-nav.adoc
+++ b/javascript-manual/modules/ROOT/content-nav.adoc
@@ -15,6 +15,7 @@
 * xref:query-advanced.adoc[Further query mechanisms]
 * xref:performance.adoc[Performance recommendations]
 * xref:browser-websockets.adoc[Usage within a browser (WebSockets)]
+* xref:object-mapping.adoc[Type checking and mapping]
 
 * *Reference*
 

--- a/javascript-manual/modules/ROOT/pages/object-mapping.adoc
+++ b/javascript-manual/modules/ROOT/pages/object-mapping.adoc
@@ -1,0 +1,229 @@
+= JavaScript Driver Record and Parameter Object Mapping
+
+Neither JavaScript nor Neo4j are strongly typed, which can lead to mistakes where a property is set to the wrong type, or an unexpected type is returned from the database and causes errors in client code.
+
+The driver offers Object Mapping to alleviate this. Object Mapping enables users to map the data in their records into classes with known propety types, and to map these classes into parameters for their queries.
+
+[NOTE]
+====
+The classes being mapped must have a constructor function that can be called without arguments, and all properties that are mapped must be publicly accessible. Mapping values into a constructor may be a future feature.
+====
+
+== Mapping Rules
+
+Given the following query:
+[source, cypher]
+----
+MATCH (p:Person)-[r:ACTED_IN]->(m:Movie)<-[:ACTED_IN]-(c:Person) 
+WHERE id(p) <> id(c) 
+RETURN p AS person, r as roles, m AS movie, COLLECT(c) AS costars
+----
+
+And the following classes:
+[source, javascript]
+----
+class ActingJob {
+    person: Person
+    movie: Movie
+    roles: Roles
+    costars: Person[]
+
+    function toString(): string {
+        return `${this.person.name} acted in ${this.movie.title} as the role(s) ${this.roles.roleNames.toString()} along with ${this.costars.map((p:person) => p.name).toString()}`
+    }
+}
+
+class  Movie {
+    title: string
+    release?: number
+    tagline?: string
+}
+
+class Person {
+    name: string
+    born?: number
+}
+
+class Roles {
+    roleNames: string[]
+}
+----
+
+This is a set of Rules objects to allow the query result to be mapped into a list of ActingJobs
+[source, javascript]
+----
+const personRules: Rules = {
+    name: rule.asString(),
+    born: rule.asNumber({ isInteger: true, optional: true })
+}
+----
+This sets string typechecking for the `name` property and Number typechecking for `born`. In addition, the born property is set to be optional and be an Integer (this will automatically convert between an integer in the database and a JavaScript number in client code).
+
+[source, javascript]
+----
+const movieRules: Rules = {
+    title: rule.asString({}),
+    release: rule.asNumber({ isInteger: true, optional: true, from: "released" }),
+    tagline: rule.asString({ optional: true })
+}
+
+const rolesRules = {
+    roleNames: rule.asList({apply: rule.asString(), from: "roles"})
+}
+----
+The Movie rules are rather similar to those for Person, but it introduces the extra rule config `from`. This simply changes the key the property is matched from, useful when there is an inconsistency in the name between code and data. 
+Since actors have a list of roles for each movie they acted in, we have to set that the roles are a list, each entry of which is a string.
+
+Now we put these rules together to create the rules to map the query result to an ActingJob object.
+[source, javascript]
+----
+const actingJobRules: Rules = {
+    person: rule.asNode({
+        convert: (node: Node) => node.as(Person, personRules)
+    }),
+    roles: rule.asRelationship({
+        convert: (rel: Relationship) => rel.as(Roles, rolesRules)
+    }),
+    movie: rule.asNode({ 
+        convert: (node:  Node) => node.as(Movie, movieRules)
+    }),
+    costars: rule.asList({
+        apply: rule.asNode({
+            convert: (node: Node) => node.as(Person, personRules)
+        })
+    })
+}
+----
+This introduces the functions `asNode`, `asRelationship`. These perform typechecking, then take optional configurations to convert into other types.
+
+A record mapped according to these Rules is then known to obey these rules and function as an ActingJob object, and IDEs like VSCode will be able to provide reasonable hints and help.
+
+The mapping rules can be used to map Result objects, individual Records or be used to by a special ResultTransformer to map the results of a query.
+
+Each of the mapping methods take the type to map to and/or a set of rules. If only the class is provided, then the driver will make a best effort, but cannot ensure type safety. If only a Rules object is supplied, then the Result or Record will be mapped, but the driver cannot provide the IDE with type hints. The recommended usage is to utilize both, later in this document there is a convenience function to make this simpler.
+
+=== Usage with transaction functions
+[source, javascript]
+----
+const res = await session.executeRead(async (tx) => {
+    return tx.run(
+    `MATCH (p:Person)-[r:ACTED_IN]->(m:Movie)<-[:ACTED_IN]-(c:Person) 
+ WHERE id(p) <> id(c) 
+ RETURN p AS person, r as roles, m AS movie, COLLECT(c) AS costars`).as(ActingJob, actingJobRules)  //The Result is here converted to a MappedResult<ActingJob> and can be consumed, subscribed to or awaited like a normal result, but all Records are replaced with ActingJobs.
+});
+
+res.records[0].person.born //after being awaited, res is a MappedQueryResult, containing an array of ActingJobs and a ResultSummary. You and your IDE can now feel safe in knowing that this is a Number.
+----
+
+=== Usage with driver.executeQuery()
+[source, javascript]
+----
+const res = await driver.executeQuery<MappedQueryResult<ActingJob>>(`MATCH (p:Person)-[r:ACTED_IN]->(m:Movie)<-[:ACTED_IN]-(c:Person) 
+ WHERE id(p) <> id(c) 
+ RETURN p AS person, r as roles, m AS movie, COLLECT(c) AS costars`, {}, {resultTransformer: neo4j.resultTransformers.hydrated(ActingJob, actingJobRules)})
+----
+
+=== Usage with session.run()
+[source, javascript]
+----
+const res2 = await session.run(
+    `MATCH (p:Person)-[r:ACTED_IN]->(m:Movie)<-[:ACTED_IN]-(c:Person) 
+ WHERE id(p) <> id(c) 
+ RETURN p AS person, r as roles, m AS movie, COLLECT(c) AS costars`
+ ).as(ActingJob, actingJobRules)
+----
+
+=== Nested Rules
+The `asObject` rule factory allows nesting in the created rules.
+
+It's useful when you're not just returning one object in your records, and allows you to map your result into multiple objects without returning full nodes or relationships to transform.
+
+Much like other instances when you can pass rules, you can also pass a class' constructor to have the `asObject` conversion convert to that class.
+
+With `asObject` we can create a set of rules for ActingJobs that can be used without returning whole Nodes and Relationships.
+
+[source, javascript]
+----
+const actingJobRulesObject: Rules = {
+    person: rule.asObject(Person, personRules),
+    role: rule.asObject(Role, roleRules),
+    movie: rule.asObject(Movie, movieRules),
+    costars: rule.asList({
+        apply: rule.asObject(Person, personRules),
+    })
+}
+
+await session.run(
+    `MATCH (p:Person)-[r:ACTED_IN]->(m:Movie)<-[:ACTED_IN]-(c:Person) 
+    WHERE id(p) <> id(c) 
+    RETURN {name: p.name, born: p.born} AS person, {name: r.characterName} as role, {released: m.release, title: m.title, tagline: m.tagline} AS movie, COLLECT({name: c.name, born: c.born}) AS costars`
+).as(ActingJob, actingJobRulesObject)
+----
+
+This setup saves on bandwitdth, especially if the nodes contain large properties like vectors which are not used for mapping.
+
+== Registering per-type default rules.
+In the examples above, we have always provided both `ActingJob` and `actingJobRules`, which requires these rules to be available in every part of the code where a query is run.
+
+The following will register this pair in global memory, meaning it persists between driver instances. This means you can run this function for every type you need mapped, and never need to explicitly provide rules to the mappers in your code unless you want the default case overridden. 
+[source, javascript]
+----
+recordObjectMapping.register(ActingJob, actingJobRules)
+----
+
+This includes inside the rules themselves. When writing the `actingJobRules`, we had to set the rule for the `person` property as
+[source, javascript]
+----
+person: rule.asNode({
+        convert: (node: Node) => node.as(Person, personRules)
+    })
+----
+however, if we know we have registed `personRules` to `Person` with `recordObjectMapping.register(ActingJob, actingJobRules)` we can replace that with:
+[source, javascript]
+----
+person: rule.asNode({
+        convert: (node: Node) => node.as(Person)
+    })
+----
+
+== Mapping Rules for Parameters
+
+The Object Mapping rules also function for Object Parameter Mapping. Allowing the same rules used to map records into object to be used to map objects to query parameters.
+
+If your domain object is already a simple JavaScript object with all the properties in the correct format to be sent as parameters there is of course no need for any mapping to occur. But if you store temporal data as Neo4j temporal types in the database but use them as strings in your Domain Object, or if your Domain Object includes functions or properties which can not or should not be sent as parameters, the mapping rules can assist in sanitizing the data for transmission.
+
+[source, javascript]
+----
+class TestObj {
+    number: number
+    string: string
+    date: string
+    list: string[]
+    constructor(number, string, date, list) {
+        this.number = number
+        this.string = string
+        this.date = date
+        this.list = list
+    }
+    function() {
+        return "function string"
+    } // the driver cannot send functions over bolt
+}
+const rules = {
+    number: neo4j.rule.asNumber({isInteger: true}),
+    string: neo4j.rule.asString(),
+    date: neo4j.rule.asDate({stringify: true}), // this will ensure date is stored as a Date in the DB and retrieved as a string
+    list: neo4j.rule.asList({ apply: neo4j.rule.asString() }),
+    function: {
+        parameterConversion: () => undefined, // explicitly skips the function when sending parameters
+        optional: true // Record mapping will attempt to get all properties of the object from the Record, we need to explicitly mark that it's okay that there is no function. This is not needed if this is only mapped to parameter objects, and never used to map Records to TestObjs
+    },
+}
+
+neo4j.RecordObjectMapping.register(TestObj, rules) // Register the rules object to the TestObj class
+
+const res = await driver.executeQuery<MappedQueryResult<ActingJob>>(
+    'RETURN $string as string, $number as number, $big_int as big_int, $date as date, $dob as dob, $list as list',
+    new TestObj(1, "hello", ["good", "bye"], "2026-09-02"), // executeQuery automatically applies the TestObj rules to this object.
+    {resultTransformer: neo4j.resultTransformers.hydrated(TestObj)})
+----

--- a/javascript-manual/modules/ROOT/pages/object-mapping.adoc
+++ b/javascript-manual/modules/ROOT/pages/object-mapping.adoc
@@ -57,7 +57,7 @@ const personRules: Rules = {
     born: rule.asNumber({ isInteger: true, optional: true })
 }
 ----
-This sets string typechecking for the `name` property and Number typechecking for `born`. In addition, the born property is set to be optional and be an Integer (this will automatically convert between an integer in the database and a JavaScript number in client code).
+This sets string type validation for the `name` property and Number type validation for `born`. In addition, the born property is set to be optional and be an Integer (this will automatically convert between an integer in the database and a JavaScript number in client code).
 
 [source, typescript]
 ----
@@ -71,8 +71,8 @@ const rolesRules = {
     roleNames: rule.asList({apply: rule.asString(), from: "roles"})
 }
 ----
-The Movie rules are rather similar to those for Person, but it introduces the extra rule config `from`. This simply changes the key the property is matched from, useful when there is an inconsistency in the name between code and data. 
-Since actors have a list of roles for each movie they acted in, we have to set that the roles are a list, each entry of which is a string.
+The Movie rules are rather similar to those for Person, but it introduces the extra rule config `from`. This simply changes the key the property is matched from, for when there is an inconsistency in the name used in client code and in the database. 
+The `asList` rule will apply the rule in it's `apply` parameter to every entry in the list.
 
 Now we put these rules together to create the rules to map the query result to an ActingJob object.
 [source, typescript]
@@ -94,13 +94,14 @@ const actingJobRules: Rules = {
     })
 }
 ----
-This introduces the functions `asNode`, `asRelationship`. These perform typechecking, then take optional configurations to convert into other types.
+This introduces the functions `asNode`, `asRelationship`. These create rules that allow conversion of Relationships and Nodes into other types.
 
-A record mapped according to these Rules is then known to obey these rules and function as an ActingJob object, and IDEs like VSCode will be able to provide reasonable hints and help.
+The mapping rules can be used to map Result objects, individual Records or be used to by a `hydrated` ResultTransformer to map the results of a query.
 
-The mapping rules can be used to map Result objects, individual Records or be used to by a special ResultTransformer to map the results of a query.
-
-Each of the mapping methods take the type to map to and/or a set of rules. If only the class is provided, then the driver will make a best effort, but cannot ensure type safety. If only a Rules object is supplied, then the Result or Record will be mapped, but the driver cannot provide the IDE with type hints. The recommended usage is to utilize both, later in this document there is a convenience function to make this simpler.
+[NOTE]
+====
+The funtions under `rule` create objects of the `Rule` class, it is possible to create custom `Rule` objects that perform more advanced type validation or conversions. The `Rule` type is exported by the driver and documented in the API docs.
+====
 
 === Usage with transaction functions
 [source, typescript]
@@ -134,13 +135,9 @@ const res2 = await session.run(
 ----
 
 === Nested Rules
-The `asObject` rule factory allows nesting in the created rules.
+The `asObject` rule factory allows createing nested rules. It allows to mapping of results into multiple objects without returning full nodes or relationships to transform.
 
-It's useful when you're not just returning one object in your records, and allows you to map your result into multiple objects without returning full nodes or relationships to transform.
-
-Much like other instances when you can pass rules, you can also pass a class' constructor to have the `asObject` conversion convert to that class.
-
-With `asObject` we can create a set of rules for ActingJobs that can be used without returning whole Nodes and Relationships.
+With `asObject`, a set of rules for ActingJobs that can be used without returning whole Nodes and Relationships can be created.
 
 [source, typescript]
 ----
@@ -163,9 +160,9 @@ await session.run(
 This setup saves on bandwitdth, especially if the nodes contain large properties like vectors which are not used for mapping.
 
 == Registering per-type default rules.
-In the examples above, we have always provided both `ActingJob` and `actingJobRules`, which requires these rules to be available in every part of the code where a query is run.
+In the examples above, both `ActingJob` and `actingJobRules` have been provided together, which requires these rules to be available in every part of the code where a query is run.
 
-The following will register this pair in global memory, meaning it persists between driver instances. This means you can run this function for every type you need mapped, and never need to explicitly provide rules to the mappers in your code unless you want the default case overridden. 
+The following code registers the rules to the object, meaning the rules do not need to be provided when using Object Mapping except to override the default.
 [source, typescript]
 ----
 recordObjectMapping.register(ActingJob, actingJobRules)
@@ -188,9 +185,9 @@ person: rule.asNode({
 
 == Mapping Rules for Parameters
 
-The Object Mapping rules also function for Object Parameter Mapping. Allowing the same rules used to map records into object to be used to map objects to query parameters.
+The Object Mapping rules also function for Object Parameter Mapping, allowing the same rules used to map records into object to be used to map objects to query parameters.
 
-If your domain object is already a simple JavaScript object with all the properties in the correct format to be sent as parameters there is of course no need for any mapping to occur. But if you store temporal data as Neo4j temporal types in the database but use them as strings in your Domain Object, or if your Domain Object includes functions or properties which can not or should not be sent as parameters, the mapping rules can assist in sanitizing the data for transmission.
+If a domain object is a simple JavaScript object with all the properties in the correct format to be sent as parameters there is no need for any mapping to occur, but if temporal data is stored as Neo4j temporal types in the database but used as strings in client code, or if a Domain Object includes functions or properties which can not or should not be sent as parameters, the mapping rules can assist in sanitizing the data for transmission.
 
 [source, typescript]
 ----

--- a/javascript-manual/modules/ROOT/pages/object-mapping.adoc
+++ b/javascript-manual/modules/ROOT/pages/object-mapping.adoc
@@ -2,7 +2,7 @@
 
 Neither JavaScript nor Neo4j are strongly typed, which can lead to mistakes where a property is set to the wrong type, or an unexpected type is returned from the database and causes errors in client code.
 
-The driver offers Object Mapping to alleviate this. Object Mapping enables users to map the data in their records into classes with known propety types, and to map these classes into parameters for their queries.
+Object Mapping enables users to map the data in their records into classes with known propety types, and to map these classes into parameters for their queries.
 
 [NOTE]
 ====
@@ -27,8 +27,14 @@ class ActingJob {
     movie: Movie
     roles: Roles
     costars: Person[]
+    constructor(person: Person, movie: Movie, roles: Roles, costars: Person[]) {
+        this.person = person
+        this.movie = movie
+        this.roles = roles
+        this.costars = costars
+    }
 
-    function toString(): string {
+    toString(): string {
         return `${this.person.name} acted in ${this.movie.title} as the role(s) ${this.roles.roleNames.toString()} along with ${this.costars.map((p:person) => p.name).toString()}`
     }
 }
@@ -36,16 +42,26 @@ class ActingJob {
 class  Movie {
     title: string
     release?: number
-    tagline?: string
+    constructor(title: string, release: number) {
+        this.title = title
+        this.release = release
+    }
 }
 
 class Person {
     name: string
     born?: number
+    constructor(name: string, born: number) {
+        this.name = name
+        this.born = born
+    }
 }
 
 class Roles {
     roleNames: string[]
+    constructor(roleNames: string[]) {
+        this.roleNames = roleNames
+    }
 }
 ----
 
@@ -64,7 +80,6 @@ This sets string type validation for the `name` property and Number type validat
 const movieRules: Rules = {
     title: rule.asString({}),
     release: rule.asNumber({ isInteger: true, optional: true, from: "released" }),
-    tagline: rule.asString({ optional: true })
 }
 
 const rolesRules = {
@@ -106,11 +121,12 @@ The funtions under `rule` create objects of the `Rule` class, it is possible to 
 === Usage with transaction functions
 [source, typescript]
 ----
-const res = await session.executeRead(async (tx) => {
+await session.executeRead(async (tx) => {
     return tx.run(
-    `MATCH (p:Person)-[r:ACTED_IN]->(m:Movie)<-[:ACTED_IN]-(c:Person) 
- WHERE id(p) <> id(c) 
- RETURN p AS person, r as roles, m AS movie, COLLECT(c) AS costars`).as(ActingJob, actingJobRules)  //The Result is here converted to a MappedResult<ActingJob> and can be consumed, subscribed to or awaited like a normal result, but all Records are replaced with ActingJobs.
+        `MATCH (p:Person)-[r:ACTED_IN]->(m:Movie)<-[:ACTED_IN]-(c:Person) 
+        WHERE id(p) <> id(c) 
+        RETURN p AS person, r as roles, m AS movie, COLLECT(c) AS costars`
+    ).as(ActingJob, actingJobRules)  //The Result is here converted to a MappedResult<ActingJob> and can be consumed, subscribed to or awaited like a normal result, but all Records are replaced with ActingJobs.
 });
 
 res.records[0].person.born //after being awaited, res is a MappedQueryResult, containing an array of ActingJobs and a ResultSummary. You and your IDE can now feel safe in knowing that this is a Number.
@@ -119,19 +135,23 @@ res.records[0].person.born //after being awaited, res is a MappedQueryResult, co
 === Usage with driver.executeQuery()
 [source, typescript]
 ----
-const res = await driver.executeQuery<MappedQueryResult<ActingJob>>(`MATCH (p:Person)-[r:ACTED_IN]->(m:Movie)<-[:ACTED_IN]-(c:Person) 
- WHERE id(p) <> id(c) 
- RETURN p AS person, r as roles, m AS movie, COLLECT(c) AS costars`, {}, {resultTransformer: neo4j.resultTransformers.hydrated(ActingJob, actingJobRules)})
+await driver.executeQuery<MappedQueryResult<ActingJob>>(
+    `MATCH (p:Person)-[r:ACTED_IN]->(m:Movie)<-[:ACTED_IN]-(c:Person) 
+    WHERE id(p) <> id(c) 
+    RETURN p AS person, r as roles, m AS movie, COLLECT(c) AS costars`,
+    {},
+    {resultTransformer: neo4j.resultTransformers.hydrated(ActingJob, actingJobRules)}
+)
 ----
 
 === Usage with session.run()
 [source, typescript]
 ----
-const res2 = await session.run(
+await session.run(
     `MATCH (p:Person)-[r:ACTED_IN]->(m:Movie)<-[:ACTED_IN]-(c:Person) 
- WHERE id(p) <> id(c) 
- RETURN p AS person, r as roles, m AS movie, COLLECT(c) AS costars`
- ).as(ActingJob, actingJobRules)
+    WHERE id(p) <> id(c) 
+    RETURN p AS person, r as roles, m AS movie, COLLECT(c) AS costars`
+).as(ActingJob, actingJobRules)
 ----
 
 === Nested Rules
@@ -143,7 +163,7 @@ With `asObject`, a set of rules for ActingJobs that can be used without returnin
 ----
 const actingJobRulesObject: Rules = {
     person: rule.asObject(Person, personRules),
-    role: rule.asObject(Role, roleRules),
+    roles: rule.asObject(Roles, rolesRules),
     movie: rule.asObject(Movie, movieRules),
     costars: rule.asList({
         apply: rule.asObject(Person, personRules),
@@ -153,7 +173,7 @@ const actingJobRulesObject: Rules = {
 await session.run(
     `MATCH (p:Person)-[r:ACTED_IN]->(m:Movie)<-[:ACTED_IN]-(c:Person) 
     WHERE id(p) <> id(c) 
-    RETURN {name: p.name, born: p.born} AS person, {name: r.characterName} as role, {released: m.release, title: m.title, tagline: m.tagline} AS movie, COLLECT({name: c.name, born: c.born}) AS costars`
+    RETURN {name: p.name, born: p.born} AS person, {roles: r.roles} as roles, {released: m.release, title: m.title} AS movie, COLLECT({name: c.name, born: c.born}) AS costars`
 ).as(ActingJob, actingJobRulesObject)
 ----
 
@@ -196,7 +216,7 @@ class TestObj {
     string: string
     date: string
     list: string[]
-    constructor(number, string, date, list) {
+    constructor(number: number, string: string, date: string, list: string[]) {
         this.number = number
         this.string = string
         this.date = date
@@ -219,8 +239,8 @@ const rules = {
 
 neo4j.RecordObjectMapping.register(TestObj, rules) // Register the rules object to the TestObj class
 
-const res = await driver.executeQuery<MappedQueryResult<ActingJob>>(
+const res = await driver.executeQuery<MappedQueryResult<TestObj>>(
     'RETURN $string as string, $number as number, $big_int as big_int, $date as date, $dob as dob, $list as list',
-    new TestObj(1, "hello", ["good", "bye"], "2026-09-02"), // executeQuery automatically applies the TestObj rules to this object.
+    new TestObj(1, "hello", "2026-09-02", ["good", "bye"]), // executeQuery automatically applies the TestObj rules to this object.
     {resultTransformer: neo4j.resultTransformers.hydrated(TestObj)})
 ----

--- a/javascript-manual/modules/ROOT/pages/object-mapping.adoc
+++ b/javascript-manual/modules/ROOT/pages/object-mapping.adoc
@@ -20,7 +20,7 @@ RETURN p AS person, r as roles, m AS movie, COLLECT(c) AS costars
 ----
 
 And the following classes:
-[source, javascript]
+[source, typescript]
 ----
 class ActingJob {
     person: Person
@@ -50,7 +50,7 @@ class Roles {
 ----
 
 This is a set of Rules objects to allow the query result to be mapped into a list of ActingJobs
-[source, javascript]
+[source, typescript]
 ----
 const personRules: Rules = {
     name: rule.asString(),
@@ -59,7 +59,7 @@ const personRules: Rules = {
 ----
 This sets string typechecking for the `name` property and Number typechecking for `born`. In addition, the born property is set to be optional and be an Integer (this will automatically convert between an integer in the database and a JavaScript number in client code).
 
-[source, javascript]
+[source, typescript]
 ----
 const movieRules: Rules = {
     title: rule.asString({}),
@@ -75,7 +75,7 @@ The Movie rules are rather similar to those for Person, but it introduces the ex
 Since actors have a list of roles for each movie they acted in, we have to set that the roles are a list, each entry of which is a string.
 
 Now we put these rules together to create the rules to map the query result to an ActingJob object.
-[source, javascript]
+[source, typescript]
 ----
 const actingJobRules: Rules = {
     person: rule.asNode({
@@ -103,7 +103,7 @@ The mapping rules can be used to map Result objects, individual Records or be us
 Each of the mapping methods take the type to map to and/or a set of rules. If only the class is provided, then the driver will make a best effort, but cannot ensure type safety. If only a Rules object is supplied, then the Result or Record will be mapped, but the driver cannot provide the IDE with type hints. The recommended usage is to utilize both, later in this document there is a convenience function to make this simpler.
 
 === Usage with transaction functions
-[source, javascript]
+[source, typescript]
 ----
 const res = await session.executeRead(async (tx) => {
     return tx.run(
@@ -116,7 +116,7 @@ res.records[0].person.born //after being awaited, res is a MappedQueryResult, co
 ----
 
 === Usage with driver.executeQuery()
-[source, javascript]
+[source, typescript]
 ----
 const res = await driver.executeQuery<MappedQueryResult<ActingJob>>(`MATCH (p:Person)-[r:ACTED_IN]->(m:Movie)<-[:ACTED_IN]-(c:Person) 
  WHERE id(p) <> id(c) 
@@ -124,7 +124,7 @@ const res = await driver.executeQuery<MappedQueryResult<ActingJob>>(`MATCH (p:Pe
 ----
 
 === Usage with session.run()
-[source, javascript]
+[source, typescript]
 ----
 const res2 = await session.run(
     `MATCH (p:Person)-[r:ACTED_IN]->(m:Movie)<-[:ACTED_IN]-(c:Person) 
@@ -142,7 +142,7 @@ Much like other instances when you can pass rules, you can also pass a class' co
 
 With `asObject` we can create a set of rules for ActingJobs that can be used without returning whole Nodes and Relationships.
 
-[source, javascript]
+[source, typescript]
 ----
 const actingJobRulesObject: Rules = {
     person: rule.asObject(Person, personRules),
@@ -166,20 +166,20 @@ This setup saves on bandwitdth, especially if the nodes contain large properties
 In the examples above, we have always provided both `ActingJob` and `actingJobRules`, which requires these rules to be available in every part of the code where a query is run.
 
 The following will register this pair in global memory, meaning it persists between driver instances. This means you can run this function for every type you need mapped, and never need to explicitly provide rules to the mappers in your code unless you want the default case overridden. 
-[source, javascript]
+[source, typescript]
 ----
 recordObjectMapping.register(ActingJob, actingJobRules)
 ----
 
 This includes inside the rules themselves. When writing the `actingJobRules`, we had to set the rule for the `person` property as
-[source, javascript]
+[source, typescript]
 ----
 person: rule.asNode({
         convert: (node: Node) => node.as(Person, personRules)
     })
 ----
 however, if we know we have registed `personRules` to `Person` with `recordObjectMapping.register(ActingJob, actingJobRules)` we can replace that with:
-[source, javascript]
+[source, typescript]
 ----
 person: rule.asNode({
         convert: (node: Node) => node.as(Person)
@@ -192,7 +192,7 @@ The Object Mapping rules also function for Object Parameter Mapping. Allowing th
 
 If your domain object is already a simple JavaScript object with all the properties in the correct format to be sent as parameters there is of course no need for any mapping to occur. But if you store temporal data as Neo4j temporal types in the database but use them as strings in your Domain Object, or if your Domain Object includes functions or properties which can not or should not be sent as parameters, the mapping rules can assist in sanitizing the data for transmission.
 
-[source, javascript]
+[source, typescript]
 ----
 class TestObj {
     number: number


### PR DESCRIPTION
This PR adds a page to the JavaScript Manual describing how to use the new Object Mapping feature.

Stable as of v6.1.